### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # zenlikes.men
 [![Documentation Status](https://readthedocs.org/projects/zenlikesmen-api/badge/?version=latest)](http://zenlikesmen-api.readthedocs.io/en/latest/?badge=latest)
 
-This is the official example API page for the [zenlikes.men](zenlikes.men) API. Consider looking at [the documentation](https://zenlikesmen-api.readthedocs.io/en/latest/).
+This is the official example API page for the [zenlikes.men](https://zenlikes.men) API. Consider looking at [the documentation](https://zenlikesmen-api.readthedocs.io/en/latest/).


### PR DESCRIPTION
Previously just said `zenlikes.men`, which leads to https://github.com/joscomputing/zenlikes.men/blob/master/zenlikes.men - which is an invalid url because that's not how links work.